### PR TITLE
Integrated PolySelect into Raster singleton

### DIFF
--- a/include/PolySelect.h
+++ b/include/PolySelect.h
@@ -13,6 +13,7 @@ private:
     Raster* raster;
     std::vector<point> points;
     int** rArray;
+    geoPoint* selection;
 
 
     // Operator predicate passed to std::sort
@@ -46,6 +47,9 @@ public:
 
     // Constructor takes a Raster object and a vector of points
     PolySelect(Raster &r, std::vector<point> pointVec);
+
+    // Free selection pointer
+    ~PolySelect();
 };
 
 

--- a/include/Raster.h
+++ b/include/Raster.h
@@ -6,9 +6,12 @@
 #define OPENGCAS_RASTER_H
 
 #include "gdal_priv.h"
+#include "structs.h"
+#include <vector>
 
 class Raster {
 private:
+    const char* _filepath;
     const char* pszFilename;
     GDALRasterBand* poBand;
     GDALDataset* poDataset;
@@ -27,18 +30,30 @@ private:
 
     int** readFromBand();
 
+    // Constructor takes a string for filename
+    // Use relative path
+    Raster(const char* file);
+
+    // Frees int** array
+    ~Raster();
+
+    static Raster r_instance;
+
 public:
     int xSize, ySize;
 
-    Raster(const char* file);
+    // Singleton instance of the class
+    // Call with Raster::Instance(const char* file)
+    // Guarantees uniqueness
+    static Raster& Instance(const char* file);
 
-    Raster();
-
-    ~Raster();
-
+    // Returns rasterBandArray
     int** getArray();
 
+    // Returns adfGeoTransform
     double* getGeoTransform();
+
+    geoPoint* poly(std::vector<point> p);
 };
 
 

--- a/src/PolySelect.cpp
+++ b/src/PolySelect.cpp
@@ -11,11 +11,6 @@
 #include <cmath>  // For atan2() and pow()
 
 
-Raster* raster;
-std::vector<point> points;
-int** rArray;
-
-
 struct PolySelect::sort {
     point center;
     bool operator()(point const& lhs, point const& rhs) {
@@ -89,7 +84,7 @@ int PolySelect::polyArea() {
 
 
 geoPoint* PolySelect::getSelection() {
-    geoPoint* selection = new geoPoint[area];
+    selection = new geoPoint[area];
     int index = 0;
     for(int row = 0; row < raster->ySize; row++) {
         for (int elem = 0; elem < raster->xSize; elem++) {
@@ -118,5 +113,11 @@ PolySelect::PolySelect(Raster &r, std::vector<point> pointVec) {
     std::sort(points.begin(), points.end(), polarVectorSort);
 
     this->area = polyArea();
+
+    // Fills selection pointer with memory
+    getSelection();
 }
 
+PolySelect::~PolySelect() {
+    //delete[] selection;
+}

--- a/src/Raster.cpp
+++ b/src/Raster.cpp
@@ -1,8 +1,9 @@
 #include "gdal_priv.h"
 
 #include "../include/Raster.h"
+#include "../include/PolySelect.h"
 #include <cassert>
-
+#include <vector>
 
 int** Raster::readFromBand() {
     int** block;
@@ -23,7 +24,7 @@ int** Raster::readFromBand() {
     return block;
 }
 
-Raster::Raster(const char* file) {
+Raster::Raster(const char* file)  : _filepath(file) {
     // Init GDAL and define attributes
     GDALAllRegister();
     this->pszFilename = file;
@@ -53,4 +54,13 @@ double* Raster::getGeoTransform() {
     return adfGeoTransform;
 }
 
+Raster& Raster::Instance(const char* file) {
+    static Raster r_instance(file);
+    return r_instance;
+}
 
+
+geoPoint* Raster::poly(std::vector<point> p) {
+    PolySelect s = PolySelect(*this, p);
+    return s.getSelection();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 int main() {
     const char* oklahoma = "../data/n33_w094_1arc_v3.tif";
 
-    Raster okRaster = Raster(oklahoma);
+    Raster& okRaster = Raster::Instance(oklahoma);
 
     std::vector<point> vec;
 
@@ -21,11 +21,11 @@ int main() {
     vec.push_back(point2);
     vec.push_back(point3);
     vec.push_back(point4);
-    PolySelect pgon = PolySelect(okRaster, vec);
 
-    geoPoint* testing = pgon.getSelection();
+    geoPoint* testing = okRaster.poly(vec);
 
-    for(int i = 0; i < pgon.area; i++) {
-        std::cout << testing[i].x << " " << testing[i].y << " " << testing[i].z << "\n";
-    }
+    for(int i = 0; i < 1000; i++)
+        std::cout << testing[i].z << "\n";
+
+    delete[] testing;
 }


### PR DESCRIPTION
Changed the interface of the Raster class so a singleton design pattern. This is a little bit more complex but it should ensure that the raster is not copied, which could lead to serious memory issues on smaller CPU's. See `src/main.cpp` for details.

I also integrated the PolySelect class into the raster class using the Poly method.

